### PR TITLE
Add static join link to navbar

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -48,6 +48,10 @@
             </li>
           {% endfor %}
         {% endif %}
+        <!-- Static join link shown on all pages -->
+        <li>
+          <a target="_blank" href="https://join.enusec.org"> Join Us <i class="fa fa-external-link"></i></a>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Currently the join link is quite hidden at the bottom of the page, this PR adds a link to the navbar on all pages to `join.enusec.org`.